### PR TITLE
Add draft API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,25 @@ Prints the list of Leagues available via the LoL Esports API.
    print(data)
    ```
 2. Run:
-   ```bash
-   python scripts/fetch_schedule.py
-   ```
+```bash
+python scripts/fetch_schedule.py
+```
+
+### Fetch Game Draft
+
+```bash
+python scripts/fetch_game_draft.py <event_id> <game_id>
+```
+
+Displays the champion picks for both teams for a specific game.
+
+```python
+from lolpredictor.api_client import LoLEsportsAPIClient
+client = LoLEsportsAPIClient()
+draft = client.get_game_draft(123456789, 1)
+print("Blue:", draft["blue_side"])
+print("Red:", draft["red_side"])
+```
 
 ### Interactive Python
 

--- a/scripts/fetch_game_draft.py
+++ b/scripts/fetch_game_draft.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import sys
+from dotenv import load_dotenv
+from lolpredictor.api_client import LoLEsportsAPIClient
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python scripts/fetch_game_draft.py <event_id> <game_id>")
+        return
+    event_id = int(sys.argv[1])
+    game_id = int(sys.argv[2])
+    load_dotenv()
+    client = LoLEsportsAPIClient()
+    draft = client.get_game_draft(event_id, game_id)
+    print("Blue side picks:", draft["blue_side"])
+    print("Red side picks:", draft["red_side"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -14,9 +14,57 @@ class DummyResponse:
 
 @pytest.fixture(autouse=True)
 def fake_get(monkeypatch):
-    def _fake(url, params=None):
-        # return a dummy "leagues" payload for any endpoint
+    event_payload = {
+        "data": {
+            "event": {
+                "match": {
+                    "games": [
+                        {
+                            "id": 1,
+                            "draft": {
+                                "actions": [
+                                    [
+                                        {
+                                            "type": "pick",
+                                            "completed": True,
+                                            "championId": "A",
+                                            "teamId": "100",
+                                        },
+                                        {
+                                            "type": "pick",
+                                            "completed": True,
+                                            "championId": "B",
+                                            "teamId": "200",
+                                        },
+                                    ],
+                                    [
+                                        {
+                                            "type": "pick",
+                                            "completed": True,
+                                            "championId": "C",
+                                            "teamId": "100",
+                                        },
+                                        {
+                                            "type": "pick",
+                                            "completed": True,
+                                            "championId": "D",
+                                            "teamId": "200",
+                                        },
+                                    ],
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    def _fake(self, url, params=None, **kwargs):
+        if url.endswith("getEventDetails"):
+            return DummyResponse(event_payload)
         return DummyResponse({"data": {"leagues": []}})
+
     import lolpredictor.api_client as mod
     monkeypatch.setattr(mod.requests.Session, "get", _fake)
     return _fake
@@ -27,3 +75,10 @@ def test_get_leagues_returns_data():
     assert "data" in result
     assert "leagues" in result["data"]
     assert isinstance(result["data"]["leagues"], list)
+
+
+def test_get_game_draft_parses_picks():
+    client = LoLEsportsAPIClient(api_key="fake-key")
+    draft = client.get_game_draft(event_id=123, game_id=1)
+    assert draft["blue_side"] == ["A", "C"]
+    assert draft["red_side"] == ["B", "D"]


### PR DESCRIPTION
## Summary
- expose `get_game_draft` API
- demonstrate draft fetching in docs and script
- test draft parsing logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3412ee708330acabeb04c464e25d